### PR TITLE
Fix curl info for php >= 7.4.0

### DIFF
--- a/src/Request/CurlHttpRequest.php
+++ b/src/Request/CurlHttpRequest.php
@@ -23,7 +23,11 @@ class CurlHttpRequest
 
     public function getInfo($option = null)
     {
-        return curl_getinfo($this->ch, $option);
+        if($opt) {
+            return curl_getinfo($this->ch, $option);
+        } else {
+            return curl_getinfo($this->ch);
+        }
     }
 
     public function close()

--- a/src/Request/CurlHttpRequest.php
+++ b/src/Request/CurlHttpRequest.php
@@ -23,11 +23,11 @@ class CurlHttpRequest
 
     public function getInfo($option = null)
     {
-        if($option) {
-            return curl_getinfo($this->ch, $option);
-        } else {
+        if (is_null($option)) {
             return curl_getinfo($this->ch);
         }
+        
+        return curl_getinfo($this->ch, $option);
     }
 
     public function close()

--- a/src/Request/CurlHttpRequest.php
+++ b/src/Request/CurlHttpRequest.php
@@ -23,7 +23,7 @@ class CurlHttpRequest
 
     public function getInfo($option = null)
     {
-        if($opt) {
+        if($option) {
             return curl_getinfo($this->ch, $option);
         } else {
             return curl_getinfo($this->ch);


### PR DESCRIPTION
PHP 7.4 does not give back all the options when passed null as second argument. This pull request fixes this.